### PR TITLE
ignore: add npm-debug.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 app/bower_components/
 coverage/
+npm-debug.log
 
 *~
 *.orig


### PR DESCRIPTION
This file is created whenever a script run by npm fails. This includes
things like e2e testing with 'npm run protractor'.
