### PR TITLE
tests: use this for local state

### DIFF
--- a/test/unit/controllersSpec.js
+++ b/test/unit/controllersSpec.js
@@ -3,13 +3,11 @@
 /* jasmine specs for controllers go here */
 
 describe('RootCtrl', function(){
-    var scope;
-
     beforeEach(module('swiftBrowser.controllers'));
 
     beforeEach(inject(function($controller) {
-        scope = {};
-        $controller('RootCtrl', {$scope: scope});
+        this.scope = {};
+        $controller('RootCtrl', {$scope: this.scope});
     }));
 
     it('should list containers', inject(function($httpBackend) {
@@ -20,45 +18,43 @@ describe('RootCtrl', function(){
         $httpBackend.whenGET('/v1/AUTH_abc?format=json')
             .respond(200, containers);
 
-        expect(scope.containers).toEqual([]);
+        expect(this.scope.containers).toEqual([]);
         $httpBackend.flush();
-        expect(scope.containers).toEqual(containers);
+        expect(this.scope.containers).toEqual(containers);
     }));
 
     it('should set sort order', function() {
-        expect(scope.orderProp).toEqual('name');
+        expect(this.scope.orderProp).toEqual('name');
     });
 
 });
 
 
 describe('ContainerCtrl', function(){
-    var scope;
-
     beforeEach(module('swiftBrowser.controllers'));
 
     function setupCtrl(params) {
         inject(function($controller) {
-            scope = {};
+            this.scope = {};
             $controller('ContainerCtrl',
-                        {$scope: scope, $routeParams: params});
+                        {$scope: this.scope, $routeParams: params});
         });
     }
 
     it('should set sort order', function() {
         setupCtrl({container: 'cont'});
-        expect(scope.orderProp).toEqual('name');
+        expect(this.scope.orderProp).toEqual('name');
     });
 
     it('should set container', function() {
         setupCtrl({container: 'cont'});
-        expect(scope.container).toEqual('cont');
+        expect(this.scope.container).toEqual('cont');
     });
 
     it('should create breadcrumbs', function() {
         setupCtrl({container: 'cont',
                    path: 'foo/bar/'});
-        expect(scope.breadcrumbs).toEqual([
+        expect(this.scope.breadcrumbs).toEqual([
             {name: '', title: 'Root'},
             {name: 'cont/', title: 'cont'},
             {name: 'cont/foo/', title: 'foo'},
@@ -94,9 +90,9 @@ describe('ContainerCtrl', function(){
         var url = '/v1/AUTH_abc/cont?prefix=foo%2F&delimiter=%2F&format=json';
         $httpBackend.whenGET(url).respond(200, reply);
 
-        expect(scope.items).toBeUndefined();
+        expect(this.scope.items).toBeUndefined();
         $httpBackend.flush();
-        expect(scope.items).toEqual(items);
+        expect(this.scope.items).toEqual(items);
     }));
 
 


### PR DESCRIPTION
Instead of declaring a variable in the top describe-block, we simply
assign to "this". This is supported by Karma, which will give us a
clean object for every test.

This makes it more clear where we get each piece of data from and
avoids accidentally leaking state between if-blocks.
