### PR TITLE
css: make count column 1em wider

### DIFF
--- a/app/css/app.css
+++ b/app/css/app.css
@@ -6,7 +6,7 @@ th.size {
 }
 
 th.count {
-    width: 7em;
+    width: 8em;
 }
 
 span.unit {


### PR DESCRIPTION
This allows for up to 99,999 objects before the line wraps. An
alternative solution would be to let the column resize itself, but I
didn't do that since it would make it differnet from page to page.
