### PR TITLE
travis: make PATH a global (non-matrix) env variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: node_js
 node_js:
   - 0.10
 env:
-  - PATH=$PWD/node_modules/.bin:$PATH
+  global:
+    - PATH=$PWD/node_modules/.bin:$PATH
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
This means that PATH is not used to define a build matrix. Travis can
use (combinations of) environment variables to define a build matrix.
Here we just want to set the value globally for the build.
