### PR TITLE
swift-simulator: correct handling of prefix

### DIFF
--- a/app/js/test/swift-simulator.js
+++ b/app/js/test/swift-simulator.js
@@ -62,13 +62,18 @@ window.setObjects = function(container, objects) {
         var prefix = params.prefix;
         var delimiter = params.delimiter;
         var results = [];
+        var subdirs = {};
         for (var i = 0; i < objects.length; i++) {
             var object = objects[i];
             var name = object.name;
             if (name.indexOf(prefix) == 0) {
                 var idx = name.indexOf(delimiter, prefix.length);
                 if (idx > -1) {
-                    results.push({subdir: name.slice(0, idx + 1)});
+                    var subdir = name.slice(0, idx + 1);
+                    if (!subdirs[subdir]) {
+                        results.push({subdir: subdir});
+                        subdirs[subdir] = true;
+                    }
                 } else {
                     results.push(object);
                 }

--- a/test/e2e/scenarios.js
+++ b/test/e2e/scenarios.js
@@ -200,6 +200,40 @@ describe('Object listing', function () {
         expect(mapGetText(names)).toEqual(['dir/', 'x.txt']);
     });
 
+    it('should understand deep pseudo-directories', function () {
+        SwiftMock.setContainers([
+            {name: "foo", count: 3, bytes: 30}
+        ]);
+        SwiftMock.setObjects('foo', [
+            {hash: "401b30e3b8b5d629635a5c613cdb7919",
+             'last_modified': "2014-08-16T13:33:21.848400",
+             bytes: 13,
+             name: "x.txt",
+             'content_type': "text/plain"},
+            {hash: "009520053b00386d1173f3988c55d192",
+             'last_modified': "2014-08-16T13:33:21.848400",
+             bytes: 10,
+             name: "deeply/y.txt",
+             'content_type': "text/plain"},
+            {hash: "009520053b00386d1173f3988c55d192",
+             'last_modified': "2014-08-16T13:33:21.848400",
+             bytes: 10,
+             name: "deeply/nested/z.txt",
+             'content_type': "text/plain"}
+        ]);
+        SwiftMock.commit();
+        browser.get('index.html#/foo/');
+
+        var links = by.css('td:nth-child(2) a');
+        expect(mapGetText(links)).toEqual(['deeply/', 'x.txt']);
+        element.all(links).first().click();
+
+        expect(mapGetText(links)).toEqual(['nested/', 'y.txt']);
+        element.all(links).first().click();
+
+        expect(mapGetText(links)).toEqual(['z.txt']);
+    });
+
     describe('selection', function () {
 
         beforeEach(function () {


### PR DESCRIPTION
Before, a request with prefix=foo and an object named foo/bar.txt
would result in '/bar.txt' being returned.

This is incorrect since Swift really returns 'foo/' in that case. In
general, objects and subdirs are always returned using their full
name, so we should not cut off the prefix like we did.
