### PR TITLE
eslint: forbid iit and ddescribe

### DIFF
--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -7,10 +7,8 @@ globals:
   afterEach: false
   beforeEach: false
   describe: false
-  ddescribe: false
   expect: false
   it: false
-  iit: false
   jasmine: false
   pending: false
   spyOn: false


### PR DESCRIPTION
These globals can be used temporarily while developing to only run a
single describe- or it-block. However, we don't want them to go into
the main repository.
