### PR TITLE
npm: make bower a hard dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "description": "Swift browser",
   "license": "Apache-2.0",
   "devDependencies": {
-    "bower": "^1.3.1",
     "coveralls": "^2.11.1",
     "grunt": "^0.4.5",
     "grunt-contrib-concat": "^0.5.0",
@@ -32,5 +31,8 @@
     "postinstall": "bower install",
     "start": "grunt start",
     "test": "grunt karma:unit"
+  },
+  "dependencies": {
+    "bower": "^1.3.1"
   }
 }


### PR DESCRIPTION
Bower is not just used for development, it is needed for production
too (deployment). This change makes 'npm install --production' work.
