### PR TITLE
grunt: place Bootstrap fonts correctly relative to CSS (fixes #176)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -146,11 +146,17 @@ module.exports = function (grunt) {
                     {expand: true,
                      cwd: 'app/bower_components',
                      src: [
-                         'bootstrap/dist/fonts/*',
                          'codemirror/mode/**/*.js',
                          '!codemirror/mode/**/test.js'
                      ],
-                     dest: '<%= build.dir %>/bower_components'}
+                     dest: '<%= build.dir %>/bower_components'},
+                    /* The Bootstrap CSS references the fonts as
+                     * ../fonts, so put them in the correct place
+                     * relative to the concatenated CSS. */
+                    {expand: true,
+                     flatten: true,
+                     src: 'app/bower_components/bootstrap/dist/fonts/*',
+                     dest: '<%= build.dir %>/fonts'}
                 ]
             }
         },


### PR DESCRIPTION
This was broken since we began using cssmin in 85f2ee006204.
