### PR TITLE
upload: fix type error

### DIFF
--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -207,8 +207,7 @@ mod.controller('ContainerCtrl', function ($scope, $swift, $stateParams,
                                                  file, headers);
                 upload.progress(function (evt) {
                     if (evt.lengthComputable) {
-                        var frac = evt.loaded / evt.total;
-                        file.uploadPct = parseInt(100.0 * frac);
+                        file.uploadPct = 100 * evt.loaded / evt.total;
                     }
                 });
                 upload.success(function () {

--- a/app/partials/upload-modal.html
+++ b/app/partials/upload-modal.html
@@ -19,7 +19,7 @@
                aria-valuenow="{{ file.uploadPct }}"
                aria-valuemin="0" aria-valuemax="100"
                ng-style="{width: file.uploadPct + '%'}">
-            {{ file.uploadPct }}%
+            {{ file.uploadPct | number:0 }}%
           </div>
         </div>
       </td>


### PR DESCRIPTION
The problem is that parseInt takes a string, not a number. So when we
passed a number this was first cast to a string, which was then parsed
as an integer, effectively throwing away the decimal part. That is
silly when Angular has a filter that can round then number for us.

This was detected with flow: http://flowtype.org/.
