### PR TITLE
travis: use new Bash Codecov upload script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: false
 node_js:
   - 0.10
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,5 @@ script:
   - grunt karma:travis
   - grunt coverage
   - grunt e2e-build
-after_script:
-  - sudo pip install codecov
-  - codecov
+after_success:
+  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This removes the need for using sudo to install a Python upload
script. By removing sudo, Travis will let our build run in a
container, which is supposed to start faster.