### PR TITLE
mock-env: partially revert d31c47a1f9ac

### DIFF
--- a/app/js/test/mock-env.js
+++ b/app/js/test/mock-env.js
@@ -49,9 +49,17 @@ window.addEventListener('DOMContentLoaded', function () {
 
         swiftSim.addContainer('empty container');
         swiftSim.setObjects('foo', {
-            'x.txt': {content: text.join('\n')},
-            'primes.py': {content: python.join('\n')},
-            'nested/z.html': {content: html.join('\n')}
+            'x.txt': {
+                content: text.join('\n')
+            },
+            'primes.py': {
+                content: python.join('\n'),
+                headers: {'Content-Type': 'text/x-python'}
+            },
+            'nested/z.html': {
+                content: html.join('\n'),
+                headers: {'Content-Type': 'text/html'}
+            }
         });
 
         /* Simple linear congruential random generator */


### PR DESCRIPTION
In d31c47a1f9ac, the Content-Type headers were removed with the
justification that the default of "text/plain" was good enough.

However, the Content-Type is used to determine the language used for
syntax highlighting and so we should keep it for the non-text files.